### PR TITLE
DEV-1055 Topology tool: Fix drag-drop alignment bug

### DIFF
--- a/src/main/resources/templates/network_diagram.html
+++ b/src/main/resources/templates/network_diagram.html
@@ -166,6 +166,7 @@
         function doLoadJSON() {
             document.getElementById('paintarea').innerHTML = "";
             workflow = new Workflow('paintarea');
+            workflow.scrollArea = document.getElementById("paint_div");
             loadJSONtext(document.getElementById('json_text').value);
         }
 
@@ -314,7 +315,7 @@
     var workflow = new Workflow("paintarea");
 
     jQuery(document).ready(function ($) {
-        workflow.scrollArea = document.getElementById("paint_div").parentNode;
+        workflow.scrollArea = document.getElementById("paint_div");
 
         //addLibraryIcon('a100baset_hub');
         addLibraryIcon('asa', 'Physical Node');


### PR DESCRIPTION
#### Branch DEV-1055-topology-tool

Steps to reproduce bugs:
1. At /networkTool, scroll the paint area (middle panel) a little to the right or bottom
2. Drag-and-drop any icons from left panel to paint area
2a. Result: the icons are not placed at cursor position
3. Add one more icon to paint area
4. Try to create a link between the anchor points of 2 icons in paint area
4a. Result: the drag-and-drop anchor snap points are misaligned with cursor

This PR fixes the bugs described above.