### PR TITLE
DEV-1195-Fix for NCL-MED-03 – Cross-Frame Scripting (XFS)

### DIFF
--- a/src/main/java/sg/ncl/DataController.java
+++ b/src/main/java/sg/ncl/DataController.java
@@ -58,6 +58,11 @@ public class DataController extends MainController {
     private static final String LI_END_TAG = "</li>";
     private static final String UL_END_TAG = "</ul>";
 
+    @ModelAttribute
+    public void setXFrameResponseHeader(HttpServletResponse response) {
+        response.setHeader("X-Frame-Options", "DENY");
+    }
+
     @RequestMapping
     public String data(Model model) {
         DatasetManager datasetManager = new DatasetManager();

--- a/src/main/java/sg/ncl/MainController.java
+++ b/src/main/java/sg/ncl/MainController.java
@@ -250,6 +250,11 @@ public class MainController {
     private static final String ADMIN_MONTHLY_USAGE_CONTRIBUTE = "admin_monthly_usage_contribute";
     private static final String ADMIN_MONTHLY_CONTRIBUTE = "admin_monthly_contribute";
 
+    @ModelAttribute
+    public void setXFrameResponseHeader(HttpServletResponse response) {
+        response.setHeader("X-Frame-Options", "DENY");
+    }
+
     @Autowired
     protected RestTemplate restTemplate;
 


### PR DESCRIPTION
NCL-MED-03 – Cross-Frame Scripting (XFS)
It is advised that the web application should set the appropriate value
for X-Frame-Options security header on the server to restrict the
website from being embedded in untrusted third-party websites. It is
suggested to set the security header value to sameorigin (only allow
current domain to frame itself) or deny (no frames allowed).